### PR TITLE
fix(lba-3828): ajout de l'authentification par token pour le chargement du dataset de classification

### DIFF
--- a/.infra/env.global.yml
+++ b/.infra/env.global.yml
@@ -1,9 +1,10 @@
 SEED_GPG_PASSPHRASE: ENC[AES256_GCM,data:4h3QUuW9Fx4OkJd98PCks34kzsuN9wciMstK69u1N6v8ByWVg5Jyj3qhszkwkp4vbgUPNxbCz0R1KFxnjAKR0YAyKVEg2i65UwTjslHbODL/DtvIHGVks9IKrEdRBHJnyYiKbA==,iv:FJ6BNuy4y0N0vvcPfNcILQhcji4IVLSh1PhSWv76fUE=,tag:XmayPdxiphPMYmXtdu81Eg==,type:str]
 LAB_SERVER_PORT: ENC[AES256_GCM,data:Wn6mzA==,iv:siYaldI1YGTO5EdtREz44eOL+XCbAMzZVOVSIdcxzBA=,tag:hT0g9V/GArbB0bQ9UimV5Q==,type:int]
 HF_TOKEN: ENC[AES256_GCM,data:YveDLp7y1ekxfAqoQLELWUXCzCuUpLOglTIQS809yKhSzYLziw==,iv:EbWScfNFGgFmOdcgxMyqvyIOmuRzAVr5OLFK7ldM3EA=,tag:3VHPvuwCYgwhRb3LIK8Z0g==,type:str]
+LBA_API_TOKEN: ENC[AES256_GCM,data:ZQOxhfdsvsPQ4O1o6gt7RvH2COjUSVzP7kx2fZ3W7tiISM5esxJ3GA==,iv:HthSCHufWn9bvOG+bC5BnsdtHsL0HjK50CjChd+zGUU=,tag:tixnoGsbN5W9xRwu1BK3ug==,type:str]
 sops:
-    lastmodified: "2026-03-04T09:37:42Z"
-    mac: ENC[AES256_GCM,data:RnnfDmwSTMftR6HGO1WLw/+gnx4/dyw039JDhthAmyzmjg8uW1dgdYXUEYxkhUc/9yZXH2onP5SnNSzgYit5R3WcfRREZO/EHFay5X4ues3++xFaMKmTeZOUdpYhVSBZtqqkBXf/LDTcnKKxane8mv8kY7NQfI8PXnAJYNI8/ZQ=,iv:2j/+H13mtoqnRsy7GZJ8dQYJQ5MzHUdeLcnLvJ/pqZ4=,tag:O7CJ5yuNijkrcEqUk9QA0A==,type:str]
+    lastmodified: "2026-03-23T13:12:02Z"
+    mac: ENC[AES256_GCM,data:BbHyIAOojnq1NzRFf/AnO/TPGfEbJw6YrRCzKwTZNn4BdlolvQ94Tz6VeqmH4dDwnb4Tyg2RulhprAOBZRnDpexVPNGqinGH8CcI/ccIGv1F0G5x2QPm0rWTx0z0Zvn9tgCVdKCNdY30xdRPUNRAFPFJLdZZepPkUf9X28xTr5o=,iv:WZUnjTuDnnECJObV4U3TEiC3ieT1XNmNrS13auWusbU=,tag:nzGcatJgnVRaZOPaGmVaxw==,type:str]
     pgp:
         - created_at: "2026-03-04T09:37:41Z"
           enc: |-

--- a/server/classifier.py
+++ b/server/classifier.py
@@ -23,7 +23,7 @@ from imblearn.pipeline import Pipeline as ImbPipeline
 import logging
 import numpy as np
 import requests
-from config import MODEL_VERSION, LANG_MODEL
+from config import MODEL_VERSION, LANG_MODEL, LBA_API_TOKEN
 tqdm.pandas()
 logger = logging.getLogger(__name__)
 
@@ -191,7 +191,16 @@ class Classifier:
             dataset: The created dataset with embeddings
         """
         # Load data
-        dataset = pd.read_json(endpoint)
+        if not LBA_API_TOKEN:
+            raise ValueError("LBA_API_TOKEN is required to load the online classification dataset")
+
+        response = requests.get(
+            endpoint,
+            headers={"Authorization": LBA_API_TOKEN},
+            timeout=(5, None),
+        )
+        response.raise_for_status()
+        dataset = pd.DataFrame(response.json())
         dataset.fillna('', inplace=True)
 
         # Update labels

--- a/server/config.py
+++ b/server/config.py
@@ -14,3 +14,6 @@ LANG_MODEL = "almanach/camembertav2-base"
 # Server configuration
 SERVER_PORT = int(os.getenv('LAB_SERVER_PORT', 8000))
 PUBLIC_VERSION = os.getenv('PUBLIC_VERSION', 'unknown')
+
+# Training token
+LBA_API_TOKEN = os.getenv('LBA_API_TOKEN')


### PR DESCRIPTION
https://tableaudebord-apprentissage.atlassian.net/browse/LBA-3828

---

## Changements

- Ajout de la variable d'environnement `LBA_API_TOKEN` dans `server/config.py`
- Ajout du secret SOPS `LBA_API_TOKEN` dans `.infra/env.global.yml`
- Modification de `classifier.py` : le chargement du dataset en ligne passe désormais par une requête HTTP authentifiée avec `Authorization: LBA_API_TOKEN` au lieu d'un simple `pd.read_json(endpoint)`
- Ajout d'une validation explicite si le token est absent

## Plan de test

- [ ] Vérifier que le serveur démarre correctement avec `LBA_API_TOKEN` défini
- [ ] Lancer un entraînement et s'assurer que le dataset est chargé sans erreur d'authentification
- [ ] Vérifier qu'une erreur explicite est levée si `LBA_API_TOKEN` est absent